### PR TITLE
非同期処理 & リハビリプランの分割生成の実装

### DIFF
--- a/gemini_client.py
+++ b/gemini_client.py
@@ -1,5 +1,6 @@
 import os
 import json
+import time
 import textwrap
 from datetime import date
 import pprint
@@ -8,6 +9,7 @@ import pprint
 # https://ai.google.dev/gemini-api/docs/quickstart?hl=ja 使い方
 from google import genai
 from google.genai import types
+from google.api_core.exceptions import ResourceExhausted, ServiceUnavailable
 from pydantic import BaseModel, Field
 from dotenv import load_dotenv
 
@@ -271,7 +273,7 @@ def _prepare_patient_facts(patient_data: dict) -> dict:
     # "心身機能・構造" カテゴリ自体が空になった場合は、それも削除
     if "心身機能・構造" in facts and not facts["心身機能・構造"]:
         del facts["心身機能・構造"]
-
+    
     return facts
 
 CHECK_TO_TEXT_MAP = {
@@ -290,108 +292,214 @@ CHECK_TO_TEXT_MAP = {
 }
 
 
-# メイン関数
-def generate_rehab_plan(patient_data):
+# --- グループ化された生成のための新しいスキーマ定義 ---
+
+class RisksAndPrecautions(BaseModel):
+    main_risks_txt: str = RehabPlanSchema.model_fields['main_risks_txt']
+    main_contraindications_txt: str = RehabPlanSchema.model_fields['main_contraindications_txt']
+
+class FunctionalLimitations(BaseModel):
+    func_pain_txt: str = RehabPlanSchema.model_fields['func_pain_txt']
+    func_rom_limitation_txt: str = RehabPlanSchema.model_fields['func_rom_limitation_txt']
+    func_muscle_weakness_txt: str = RehabPlanSchema.model_fields['func_muscle_weakness_txt']
+    func_swallowing_disorder_txt: str = RehabPlanSchema.model_fields['func_swallowing_disorder_txt']
+    func_behavioral_psychiatric_disorder_txt: str = RehabPlanSchema.model_fields['func_behavioral_psychiatric_disorder_txt']
+    func_nutritional_disorder_txt: str = RehabPlanSchema.model_fields['func_nutritional_disorder_txt']
+    func_excretory_disorder_txt: str = RehabPlanSchema.model_fields['func_excretory_disorder_txt']
+    func_pressure_ulcer_txt: str = RehabPlanSchema.model_fields['func_pressure_ulcer_txt']
+    func_contracture_deformity_txt: str = RehabPlanSchema.model_fields['func_contracture_deformity_txt']
+    func_motor_muscle_tone_abnormality_txt: str = RehabPlanSchema.model_fields['func_motor_muscle_tone_abnormality_txt']
+    func_disorientation_txt: str = RehabPlanSchema.model_fields['func_disorientation_txt']
+    func_memory_disorder_txt: str = RehabPlanSchema.model_fields['func_memory_disorder_txt']
+
+class Goals(BaseModel):
+    goals_1_month_txt: str = RehabPlanSchema.model_fields['goals_1_month_txt']
+    goals_at_discharge_txt: str = RehabPlanSchema.model_fields['goals_at_discharge_txt']
+
+class TreatmentPolicy(BaseModel):
+    policy_treatment_txt: str = RehabPlanSchema.model_fields['policy_treatment_txt']
+    policy_content_txt: str = RehabPlanSchema.model_fields['policy_content_txt']
+    adl_equipment_and_assistance_details_txt: str = RehabPlanSchema.model_fields['adl_equipment_and_assistance_details_txt']
+
+class ActionPlans(BaseModel):
+    goal_a_action_plan_txt: str = RehabPlanSchema.model_fields['goal_a_action_plan_txt']
+    goal_s_env_action_plan_txt: str = RehabPlanSchema.model_fields['goal_s_env_action_plan_txt']
+    goal_p_action_plan_txt: str = RehabPlanSchema.model_fields['goal_p_action_plan_txt']
+    goal_s_psychological_action_plan_txt: str = RehabPlanSchema.model_fields['goal_s_psychological_action_plan_txt']
+    goal_s_3rd_party_action_plan_txt: str = RehabPlanSchema.model_fields['goal_s_3rd_party_action_plan_txt']
+
+
+# --- 統合スキーマ ---
+class CurrentAssessment(RisksAndPrecautions, FunctionalLimitations):
+    """患者の現状評価（リスク、禁忌、機能障害）をまとめて生成するためのスキーマ"""
+    pass
+
+class ComprehensiveTreatmentPlan(TreatmentPolicy, ActionPlans):
+    """目標達成のための包括的な治療計画（全体方針、ADL詳細、個別計画）をまとめて生成するためのスキーマ"""
+    pass
+
+
+# 生成をグループ単位で行うためのリスト
+GENERATION_GROUPS = [
+    CurrentAssessment,          # ステップ1: 現状評価（リスク、禁忌、機能障害）
+    Goals,                      # ステップ2: 目標設定
+    ComprehensiveTreatmentPlan, # ステップ3: 包括的な治療計画
+]
+
+# ユーザーが既に入力した項目はAI生成をスキップする
+USER_INPUT_FIELDS = ["main_comorbidities_txt"]
+
+
+def _build_group_prompt(group_schema: type[BaseModel], patient_facts_str: str, generated_plan_so_far: dict) -> str:
+    """グループ生成用のプロンプトを構築する"""
+    return textwrap.dedent(f"""
+        # 役割
+        あなたは、経験豊富なリハビリテーション科の指導医です。
+        患者の個別性を最大限に尊重し、一貫性のあるリハビリテーション実施計画書を作成してください。
+
+        # 患者データ (事実情報)
+        これは、患者の客観的な評価結果や基本情報です。
+        ```json
+        {patient_facts_str}
+        ```
+
+        # これまでの生成結果
+        これは、あなたがこれまでに生成した計画書の一部です。
+        この内容を十分に参照し、矛盾のない、より質の高い記述を生成してください。
+        ```json
+        {json.dumps(generated_plan_so_far, indent=2, ensure_ascii=False)}
+        ```
+
+        # 作成指示
+        上記の「患者データ」と「これまでの生成結果」を統合的に解釈し、以下のJSONスキーマに厳密に従って、各項目を日本語で生成してください。
+        - スキーマの`description`をよく読み、専門的かつ具体的な内容を記述してください。
+        - 各項目は、他の項目との関連性や一貫性を保つように記述してください。
+        - 患者データから判断して該当しない、または情報が不足している場合は、必ず「特記なし」とだけ記述してください。
+
+        ```json
+        {json.dumps(group_schema.model_json_schema(), indent=2, ensure_ascii=False)}
+        ```
+    """)
+
+def generate_rehab_plan_stream(patient_data: dict):
     """
-    患者データを基にプロンプトを生成し、Gemini APIにリハビリ計画の作成を依頼する
+    患者データを基に、リハビリ計画の各項目を一つずつ生成し、ストリーミングで返すジェネレータ関数。
     """
+
     if USE_DUMMY_DATA:
         print("--- ダミーデータを使用しています ---")
-        return get_dummy_plan()
+        dummy_plan = get_dummy_plan()
+        for key, value in dummy_plan.items():
+            time.sleep(0.2)
+            event_data = json.dumps({"key": key, "value": value})
+            yield f"event: update\ndata: {event_data}\n\n"
+        yield "event: finished\ndata: {}\n\n"
+        return
 
     try:
         # 1. プロンプト用に患者の事実情報を整形
         patient_facts = _prepare_patient_facts(patient_data)
+        patient_facts_str = json.dumps(patient_facts, indent=2, ensure_ascii=False)
 
-        # 2. プロンプトを部品に分割して安全に組み立てる
-        prompt_start = textwrap.dedent("""
-            # 役割
-            あなたは、経験豊富なリハビリテーション科の指導医です。提供された客観的な患者データを基に、専門的な臨床推論を行い、リハビリテーション実施計画書の各項目を日本語で作成してください。
+        generated_plan_so_far = {}
 
-            # 患者データ (事実情報)
-        """)
+        # ユーザーが既に入力済みの項目を先に処理
+        for field_name in USER_INPUT_FIELDS:
+            if patient_data.get(field_name):
+                value = patient_data[field_name]
+                generated_plan_so_far[field_name] = value
+                event_data = json.dumps({"key": field_name, "value": value})
+                yield f"event: update\ndata: {event_data}\n\n"
 
-        prompt_end = textwrap.dedent("""
-            # 作成指示
-            上記の患者データを深く分析し、以下の各項目について、日本の医療現場で通用する専門的かつ具体的な内容を生成してください。生成する内容は、JSON形式で、指示されたスキーマに厳密に従う必要があります。事実だけでなく、あなたの専門的な考察を加えてください。
-        """)
+        # 2. グループごとに生成
+        for group_schema in GENERATION_GROUPS:
+            # 3. プロンプトの構築
+            prompt = _build_group_prompt(group_schema, patient_facts_str, generated_plan_so_far)
 
-        json_data_string = json.dumps(patient_facts, indent=2, ensure_ascii=False)
-        prompt = f"{prompt_start}\n```json\n{json_data_string}\n```\n\n{prompt_end}"
+            # 4. API呼び出し実行 (JSONモード)
+            generation_config = types.GenerateContentConfig(
+                response_mime_type="application/json",
+                response_schema=group_schema,
+            )
 
-        print("--- 生成されたプロンプト ---\n" + prompt + "\n--------------------------")
+            # --- リトライ処理の追加 ---
+            max_retries = 3
+            backoff_factor = 2  # 初回待機時間（秒）
+            response = None
 
-        # 3. API呼び出し設定
-        # JSONのように構造化した出力を設定する方法
-        # https://ai.google.dev/gemini-api/docs/structured-output?hl=ja
+            for attempt in range(max_retries):
+                try:
+                    response = client.models.generate_content(
+                        model="gemini-1.5-flash-latest", contents=prompt, config=generation_config
+                    )
+                    break  # 成功した場合はループを抜ける
+                except (ResourceExhausted, ServiceUnavailable) as e:
+                    if attempt < max_retries - 1:
+                        wait_time = backoff_factor * (2 ** attempt)
+                        print(f"API rate limit or overload error: {e}. Retrying in {wait_time} seconds... (Attempt {attempt + 1}/{max_retries})")
+                        time.sleep(wait_time)
+                    else:
+                        print(f"API call failed after {max_retries} retries.")
+                        raise e  # 最終的に失敗した場合はエラーを再送出
 
-        # configでJSON形式とそのスキーマを指定することで、安定してJSONを出力させます。
-        generation_config = types.GenerateContentConfig(
-            response_mime_type="application/json",
-            response_schema=RehabPlanSchema,
-        )
+            if not response.parsed:
+                raise Exception(f"グループ {group_schema.__name__} のJSON生成に失敗しました。応答: {response.text}")
 
-        # 4. API呼び出し実行
-        response = client.models.generate_content(model="gemini-2.5-flash-lite", contents=prompt, config=generation_config)
+            group_result = response.parsed.model_dump()
 
-        # 5. 結果の処理 パースした結果(.parsed)を使用します。
-        if response.parsed:
-            # Pydanticモデルを辞書に変換して返す
-            ai_plan = response.parsed.model_dump()
+            # 5. グループ内の各項目を処理してストリームに流す
+            for field_name, generated_text in group_result.items():
+                final_text = generated_text
 
-            print("\n--- AIからの生の応答 ---")
-            pprint.pprint(ai_plan)
-            print("------------------------\n")
-            print("--- 上書き処理のチェック ---")
+                # チェックなし項目の上書き処理
+                is_truly_checked = True
+                if field_name in CHECK_TO_TEXT_MAP.values():
+                    chk_key = next((chk for chk, txt in CHECK_TO_TEXT_MAP.items() if txt == field_name), None)
+                    if chk_key:
+                        is_checked_in_db = patient_data.get(chk_key)
+                        is_truly_checked = str(is_checked_in_db).lower() in ['true', '1', 'on']
 
-            # チェックボックスとテキスト項目のペアをループ処理
-            for chk_key, txt_key in CHECK_TO_TEXT_MAP.items():
-                # データベースから取得した元の患者データで、チェックボックスが「チェックされていない」
-                # (値がFalse、0、またはキー自体が存在しない)場合
-                is_checked_in_db = patient_data.get(chk_key)
-                print(f"キー: {chk_key}, DBの値: {is_checked_in_db}, 型: {type(is_checked_in_db)}, 上書き判定: {not is_checked_in_db}")
-
-                is_truly_checked = str(is_checked_in_db).lower() in ['true', '1', 'on']
-                print(
-                    f"キー: {chk_key}, "
-                    f"DBの値: {is_checked_in_db} (型: {type(is_checked_in_db)}), "
-                    f"チェック判定: {is_truly_checked}, "
-                    f"AIの生成内容: '{ai_plan.get(txt_key)}'"
-                )
                 if not is_truly_checked:
-                    # AIが何を生成したかに関わらず、最終的なテキストを「特記なし」で強制的に上書きする。
-                    # これにより、「チェックがないのに詳細が書かれる」問題を完全に防ぐ。
-                    if ai_plan.get(txt_key) != "特記なし":
-                        print(f"   -> 上書き実行: '{ai_plan.get(txt_key)}' を  チェックがないため '特記なし' に変更します。")
-                    ai_plan[txt_key] = "特記なし"
+                    final_text = "特記なし"
+                # チェックありなのに「特記なし」と生成された場合の復元処理
+                elif is_truly_checked and generated_text == "特記なし":
+                    original_text = patient_data.get(field_name)
+                    if original_text and original_text != "特記なし":
+                        final_text = original_text
 
-                # もしDBでチェックが入っているのにAIが「特記なし」と答えた場合の対策
-                else:
-                    # もしチェック有にも関わらずAIが'特記なし'と生成した場合、
-                    # 元のDBに何か記述があればそちらを優先する（ユーザー入力を保護）
-                    original_text = patient_data.get(txt_key)
-                    if ai_plan.get(txt_key) == "特記なし" and original_text:
-                         print(f"   -> AIは'特記なし'と生成しましたが、DBに元の記述があるため復元します: '{original_text}'")
-                         ai_plan[txt_key] = original_text
+                # 生成結果を格納し、ストリームに流す
+                generated_plan_so_far[field_name] = final_text
+                event_data = json.dumps({"key": field_name, "value": final_text})
+                yield f"event: update\ndata: {event_data}\n\n"
 
-
-            # ユーザーが既に入力した併存疾患はAIの生成で上書きしない
-            if patient_data.get("main_comorbidities_txt"):
-                ai_plan["main_comorbidities_txt"] = patient_data["main_comorbidities_txt"]
-
-            print("--- 上書き処理後の最終結果 ---")
-            pprint.pprint(ai_plan)
-            print("-----------------------------")
-
-            return ai_plan
-        else:
-            print("JSONパースエラー: レスポンスをスキーマに沿ってパースできませんでした。")
-            print(f"--- AIからの不正な応答 ---\n{response.text}\n--------------------")
-            return {"error": "AIからの応答をJSONとして解析できませんでした。"}
+        # 6. 完了イベントを送信
+        yield "event: finished\ndata: {}\n\n"
 
     except Exception as e:
         print(f"Gemini API呼び出し中に予期せぬエラーが発生しました: {e}")
-        return {"error": f"AIとの通信中にエラーが発生しました: {e}"}
+        error_message = f"AIとの通信中にエラーが発生しました: {e}"
+        error_event = f"event: error\ndata: {json.dumps({'error': error_message})}\n\n"
+        yield error_event
+
+
+
+# メイン関数 (旧関数)
+def generate_rehab_plan(patient_data):
+    """
+    [非推奨] 患者データを基にプロンプトを生成し、Gemini APIにリハビリ計画の作成を依頼する
+    この関数は下位互換性のために残されていますが、新しいストリーミング方式の使用が推奨されます。
+    """
+    stream = generate_rehab_plan_stream(patient_data)
+    full_plan = {}
+    for event in stream:
+        if event.startswith("event: update"):
+            data_str = event.split("data: ")[1].strip()
+            data = json.loads(data_str)
+            full_plan[data['key']] = data['value']
+        elif event.startswith("event: error"):
+            data_str = event.split("data: ")[1].strip()
+            return json.loads(data_str)
+    return full_plan
 
 
 # テスト用ダミーデータ
@@ -441,16 +549,21 @@ if __name__ == "__main__":
 
     USE_DUMMY_DATA = False
 
-    generated_plan = generate_rehab_plan(sample_patient_data)
+    stream_generator = generate_rehab_plan_stream(sample_patient_data)
 
     print("\n--- 生成された計画 (結果) ---")
-    import pprint
+    final_plan = {}
+    error = None
+    for event in stream_generator:
+        print(event) # ストリームの各イベントを表示
+        if "event: update" in event:
+            data = json.loads(event.split("data: ")[1])
+            final_plan[data['key']] = data['value']
+        elif "event: error" in event:
+            error = json.loads(event.split("data: ")[1])
 
-    # pprintを使うと、辞書を人間が読みやすい形に整形して表示してくれます。
-    pprint.pprint(generated_plan)
-    print("--------------------------")
-
-    if "error" in generated_plan:
-        print("\nテスト実行中にエラーが検出されました。")
+    if error:
+        print(f"\nテスト実行中にエラーが検出されました: {error}")
     else:
         print("\nテストが正常に完了しました。")
+        pprint.pprint(final_plan)

--- a/templates/confirm.html
+++ b/templates/confirm.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>【確認・修正】リハビリテーション実施計画書</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <style>
         .patient-info {
             background-color: var(--secondary-color);
@@ -15,6 +17,14 @@
             border-left: 5px solid var(--primary-color);
         }
 
+        .generation-status-icon {
+            width: 24px;
+            margin-right: 8px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            vertical-align: middle;
+        }
         .ai-label::after {
             content: 'AIによる提案 (編集可)';
             font-size: 12px;
@@ -89,7 +99,15 @@
     <div class="container">
         <header>
             <h1>【確認・修正】リハビリテーション実施計画書</h1>
-            <p>AIが生成した以下の計画案を確認し、必要に応じて内容を修正してください。<br>修正後、「この内容で確定して保存」ボタンを押すとExcelファイルが出力されます。</p>
+            <div id="generation-header-status" class="alert alert-info">
+                <div class="d-flex align-items-center">
+                    <div class="spinner-border spinner-border-sm me-2" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                    <span>AIが計画書を生成中です。完了した項目から編集できます...</span>
+                </div>
+            </div>
+            <p id="generation-finished-text" style="display: none;">AIによる生成が完了しました。内容を確認・修正し、「この内容で確定して保存」ボタンを押してください。</p>
         </header>
 
         <div class="patient-info">
@@ -98,6 +116,8 @@
         </div>
 
         <form id="confirm-form" action="{{ url_for('save_plan') }}" method="post">
+            <input type="hidden" name="patient_id" value="{{ patient_data.patient_id }}">
+
             {% set editable_keys = ['main_risks_txt', 'main_contraindications_txt',
             'func_pain_txt', 'func_rom_limitation_txt', 'func_muscle_weakness_txt',
             'func_swallowing_disorder_txt', 'func_behavioral_psychiatric_disorder_txt',
@@ -122,136 +142,136 @@
             <h2 class="section-title">【1枚目】所見・方針</h2>
 
             <div class="form-group">
-                <label for="main_risks_txt" class="ai-label">安静度・リスク</label>
+                <label for="main_risks_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-main_risks_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>安静度・リスク</label>
                 <textarea name="main_risks_txt" id="main_risks_txt"
-                    class="form-control">{{ plan.main_risks_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.main_risks_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="main_contraindications_txt" class="ai-label">禁忌・特記事項</label>
+                <label for="main_contraindications_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-main_contraindications_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>禁忌・特記事項</label>
                 <textarea name="main_contraindications_txt" id="main_contraindications_txt"
-                    class="form-control">{{ plan.main_contraindications_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.main_contraindications_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="adl_equipment_and_assistance_details_txt" class="ai-label">使用用具及び介助内容等</label>
+                <label for="adl_equipment_and_assistance_details_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-adl_equipment_and_assistance_details_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>使用用具及び介助内容等</label>
                 <textarea name="adl_equipment_and_assistance_details_txt" id="adl_equipment_and_assistance_details_txt"
-                    class="form-control">{{ plan.adl_equipment_and_assistance_details_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.adl_equipment_and_assistance_details_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="goals_1_month_txt" class="ai-label">目標（1ヶ月）</label>
+                <label for="goals_1_month_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-goals_1_month_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>目標（1ヶ月）</label>
                 <textarea name="goals_1_month_txt" id="goals_1_month_txt"
-                    class="form-control">{{ plan.goals_1_month_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.goals_1_month_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="goals_at_discharge_txt" class="ai-label">目標（終了時）</label>
+                <label for="goals_at_discharge_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-goals_at_discharge_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>目標（終了時）</label>
                 <textarea name="goals_at_discharge_txt" id="goals_at_discharge_txt"
-                    class="form-control">{{ plan.goals_at_discharge_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.goals_at_discharge_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="policy_treatment_txt" class="ai-label">治療方針</label>
+                <label for="policy_treatment_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-policy_treatment_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>治療方針</label>
                 <textarea name="policy_treatment_txt" id="policy_treatment_txt"
-                    class="form-control">{{ plan.policy_treatment_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.policy_treatment_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="policy_content_txt" class="ai-label">治療内容</label>
+                <label for="policy_content_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-policy_content_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>治療内容</label>
                 <textarea name="policy_content_txt" id="policy_content_txt" class="form-control"
-                    style="min-height: 200px;">{{ plan.policy_content_txt }}</textarea>
+                    style="min-height: 200px;" readonly placeholder="AIが生成中です...">{{ plan.policy_content_txt }}</textarea>
             </div>
 
             <h3 class="section-title">心身機能・構造に関する特記事項</h3>
             <div class="form-group">
-                <label for="func_pain_txt" class="ai-label">疼痛</label>
+                <label for="func_pain_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_pain_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>疼痛</label>
                 <textarea name="func_pain_txt" id="func_pain_txt"
-                    class="form-control">{{ plan.func_pain_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_pain_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="func_rom_limitation_txt" class="ai-label">関節可動域制限</label>
+                <label for="func_rom_limitation_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_rom_limitation_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>関節可動域制限</label>
                 <textarea name="func_rom_limitation_txt" id="func_rom_limitation_txt"
-                    class="form-control">{{ plan.func_rom_limitation_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_rom_limitation_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="func_muscle_weakness_txt" class="ai-label">筋力低下</label>
+                <label for="func_muscle_weakness_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_muscle_weakness_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>筋力低下</label>
                 <textarea name="func_muscle_weakness_txt" id="func_muscle_weakness_txt"
-                    class="form-control">{{ plan.func_muscle_weakness_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_muscle_weakness_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="func_swallowing_disorder_txt" class="ai-label">摂食嚥下障害</label>
+                <label for="func_swallowing_disorder_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_swallowing_disorder_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>摂食嚥下障害</label>
                 <textarea name="func_swallowing_disorder_txt" id="func_swallowing_disorder_txt"
-                    class="form-control">{{ plan.func_swallowing_disorder_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_swallowing_disorder_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="func_behavioral_psychiatric_disorder_txt" class="ai-label">精神行動障害</label>
+                <label for="func_behavioral_psychiatric_disorder_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_behavioral_psychiatric_disorder_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>精神行動障害</label>
                 <textarea name="func_behavioral_psychiatric_disorder_txt" id="func_behavioral_psychiatric_disorder_txt"
-                    class="form-control">{{ plan.func_behavioral_psychiatric_disorder_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_behavioral_psychiatric_disorder_txt }}</textarea>
             </div>
 
             <div class="form-group">
-                <label for="func_nutritional_disorder_txt" class="ai-label">栄養障害</label>
+                <label for="func_nutritional_disorder_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_nutritional_disorder_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>栄養障害</label>
                 <textarea name="func_nutritional_disorder_txt" id="func_nutritional_disorder_txt"
-                    class="form-control">{{ plan.func_nutritional_disorder_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_nutritional_disorder_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="func_excretory_disorder_txt" class="ai-label">排泄機能障害</label>
+                <label for="func_excretory_disorder_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_excretory_disorder_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>排泄機能障害</label>
                 <textarea name="func_excretory_disorder_txt" id="func_excretory_disorder_txt"
-                    class="form-control">{{ plan.func_excretory_disorder_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_excretory_disorder_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="func_pressure_ulcer_txt" class="ai-label">褥瘡</label>
+                <label for="func_pressure_ulcer_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_pressure_ulcer_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>褥瘡</label>
                 <textarea name="func_pressure_ulcer_txt" id="func_pressure_ulcer_txt"
-                    class="form-control">{{ plan.func_pressure_ulcer_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_pressure_ulcer_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="func_contracture_deformity_txt" class="ai-label">拘縮・変形</label>
+                <label for="func_contracture_deformity_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_contracture_deformity_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>拘縮・変形</label>
                 <textarea name="func_contracture_deformity_txt" id="func_contracture_deformity_txt"
-                    class="form-control">{{ plan.func_contracture_deformity_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_contracture_deformity_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="func_motor_muscle_tone_abnormality_txt" class="ai-label">筋緊張異常</label>
+                <label for="func_motor_muscle_tone_abnormality_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_motor_muscle_tone_abnormality_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>筋緊張異常</label>
                 <textarea name="func_motor_muscle_tone_abnormality_txt" id="func_motor_muscle_tone_abnormality_txt"
-                    class="form-control">{{ plan.func_motor_muscle_tone_abnormality_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_motor_muscle_tone_abnormality_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="func_disorientation_txt" class="ai-label">見当識障害</label>
+                <label for="func_disorientation_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_disorientation_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>見当識障害</label>
                 <textarea name="func_disorientation_txt" id="func_disorientation_txt"
-                    class="form-control">{{ plan.func_disorientation_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_disorientation_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="func_memory_disorder_txt" class="ai-label">記憶障害</label>
+                <label for="func_memory_disorder_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-func_memory_disorder_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>記憶障害</label>
                 <textarea name="func_memory_disorder_txt" id="func_memory_disorder_txt"
-                    class="form-control">{{ plan.func_memory_disorder_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.func_memory_disorder_txt }}</textarea>
             </div>
 
 
             <h2 class="section-title">【2枚目】目標詳細・具体的な対応方針</h2>
             <div class="form-group">
-                <label for="goal_p_action_plan_txt" class="ai-label">参加の具体的な対応方針</label>
+                <label for="goal_p_action_plan_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-goal_p_action_plan_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>参加の具体的な対応方針</label>
                 <textarea name="goal_p_action_plan_txt" id="goal_p_action_plan_txt"
-                    class="form-control">{{ plan.goal_p_action_plan_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.goal_p_action_plan_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="goal_a_action_plan_txt" class="ai-label">活動の具体的な対応方針</label>
+                <label for="goal_a_action_plan_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-goal_a_action_plan_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>活動の具体的な対応方針</label>
                 <textarea name="goal_a_action_plan_txt" id="goal_a_action_plan_txt"
-                    class="form-control">{{ plan.goal_a_action_plan_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.goal_a_action_plan_txt }}</textarea>
             </div>
 
             <div class="form-group">
-                <label for="goal_s_psychological_action_plan_txt" class="ai-label">心理の具体的な対応方針</label>
+                <label for="goal_s_psychological_action_plan_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-goal_s_psychological_action_plan_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>心理の具体的な対応方針</label>
                 <textarea name="goal_s_psychological_action_plan_txt" id="goal_s_psychological_action_plan_txt"
-                    class="form-control">{{ plan.goal_s_psychological_action_plan_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.goal_s_psychological_action_plan_txt }}</textarea>
             </div>
             <div class="form-group">
-                <label for="goal_s_env_action_plan_txt" class="ai-label">環境の具体的な対応方針</label>
+                <label for="goal_s_env_action_plan_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-goal_s_env_action_plan_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>環境の具体的な対応方針</label>
                 <textarea name="goal_s_env_action_plan_txt" id="goal_s_env_action_plan_txt"
-                    class="form-control">{{ plan.goal_s_env_action_plan_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.goal_s_env_action_plan_txt }}</textarea>
             </div>
 
             <div class="form-group">
-                <label for="goal_s_3rd_party_action_plan_txt" class="ai-label">第三者の不利に関する具体的な対応方針</label>
+                <label for="goal_s_3rd_party_action_plan_txt" class="ai-label d-flex align-items-center"><span class="generation-status-icon" id="icon-goal_s_3rd_party_action_plan_txt"><div class="spinner-border spinner-border-sm text-secondary" role="status"></div></span>第三者の不利に関する具体的な対応方針</label>
                 <textarea name="goal_s_3rd_party_action_plan_txt" id="goal_s_3rd_party_action_plan_txt"
-                    class="form-control">{{ plan.goal_s_3rd_party_action_plan_txt }}</textarea>
+                    class="form-control" readonly placeholder="AIが生成中です...">{{ plan.goal_s_3rd_party_action_plan_txt }}</textarea>
             </div>
 
             <div class="form-group">
-                <button type="submit" id="submit-button" class="submit-btn">この内容で確定して保存</button>
+                <button type="submit" id="submit-button" class="submit-btn" disabled>AI生成完了までお待ちください...</button>
             </div>
         </form>
 
@@ -264,27 +284,21 @@
             <button id="reset-all-button" class="submit-btn">全入力欄<br>リセット</button>
         </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
+            // 全ての処理をこのイベントリスナー内にまとめる
             const form = document.getElementById('confirm-form');
             const submitButton = document.getElementById('submit-button');
-            form.addEventListener('submit', function () {
+            form.addEventListener('submit', function (e) {
                 submitButton.disabled = true;
                 submitButton.textContent = '保存・作成中...';
             });
-        });
-
-        // ボタン・入力欄色関係
-        document.addEventListener('DOMContentLoaded', () => {
-            const undoBtn = document.getElementById('global-undo-button');
-            const redoBtn = document.getElementById('global-redo-button');
-            const resetActiveBtn = document.getElementById('reset-active-button');
-            const resetAllBtn = document.getElementById('reset-all-button');
 
             const historyManager = {};
             let activeInputId = null;
             const defaultValues = {};
-            
+
             // 入力欄の色更新
             function updateElementStyle(element) {
                 if (!element || !element.id || defaultValues[element.id] === undefined) return;
@@ -301,13 +315,15 @@
                 }
             }
 
-            // ページ読み込み時にデフォルト値を保存し、初期スタイルを適用
-            document.querySelectorAll('.form-control').forEach(element => {
-                if (element.id) {
-                    defaultValues[element.id] = element.value;
-                    updateElementStyle(element);
-                }
-            });
+            function initializeDefaultValues() {
+                // ページ読み込み時またはAI生成完了時にデフォルト値を保存し、初期スタイルを適用
+                document.querySelectorAll('.form-control').forEach(element => {
+                    if (element.id && !element.readOnly) { // 編集可能なものだけ
+                        defaultValues[element.id] = element.value;
+                        updateElementStyle(element);
+                    }
+                });
+            }
 
             // focusin イベントを監視
             document.addEventListener('focusin', (event) => {
@@ -332,10 +348,10 @@
                     if (!data) return;
 
                     clearTimeout(data.debounceTimer);
-                    
+
                     data.debounceTimer = setTimeout(() => {
                         if (event.target.value === data.history[data.index]) return;
-                        
+
                         data.history.splice(data.index + 1);
                         data.history.push(event.target.value);
                         data.index = data.history.length - 1;
@@ -346,10 +362,15 @@
             });
 
             // --- ボタンの処理 ---
+            const undoBtn = document.getElementById('global-undo-button');
+            const redoBtn = document.getElementById('global-redo-button');
+            const resetActiveBtn = document.getElementById('reset-active-button');
+            const resetAllBtn = document.getElementById('reset-all-button');
+
             // 「元に戻す」ボタン
             undoBtn.addEventListener('click', () => {
                 if (!activeInputId || !historyManager[activeInputId]) return;
-                
+
                 const data = historyManager[activeInputId];
                 if (data.index > 0) {
                     data.index--;
@@ -384,7 +405,7 @@
 
                 if (element && defaultValue !== undefined) {
                     element.value = defaultValue;
-                    
+
                     const data = historyManager[activeInputId];
                     if (data && data.history[data.index] !== defaultValue) {
                         data.history.splice(data.index + 1);
@@ -400,7 +421,7 @@
                 if (!confirm('全ての入力内容を初期状態に戻します。よろしいですか？')) {
                     return;
                 }
-                
+
                 document.querySelectorAll('.form-control').forEach(element => {
                     const id = element.id;
                     if (!id) return;
@@ -409,7 +430,7 @@
                     if (defaultValue !== undefined) {
                         element.value = defaultValue;
                     }
-                    
+
                     if (historyManager[id]) {
                         historyManager[id].history = [defaultValue];
                         historyManager[id].index = 0;
@@ -417,6 +438,91 @@
                     updateElementStyle(element);
                 });
             });
+
+            // AIによるストリーミング生成処理
+            {% if is_generating %}
+            const generationHeaderStatus = document.getElementById('generation-header-status');
+            const generationFinishedText = document.getElementById('generation-finished-text');
+
+            const formData = new FormData();
+            formData.append('patient_id', '{{ patient_data.patient_id }}');
+            formData.append('therapist_notes', '{{ patient_data.therapist_notes | e }}');
+
+            fetch("{{ url_for('generate_plan_stream') }}", {
+                method: 'POST',
+                body: formData
+            }).then(response => {
+                if (!response.ok) {
+                    throw new Error(`Server responded with ${response.status}`);
+                }
+                const reader = response.body.getReader();
+                const decoder = new TextDecoder();
+
+                function push() {
+                    reader.read().then(({ done, value }) => {
+                        if (done) {
+                            console.log('Stream finished.');
+                            return;
+                        }
+                        const chunk = decoder.decode(value, { stream: true });
+                        // SSE形式のデータをパース
+                        const events = chunk.split('\n\n').filter(e => e.trim());
+
+                        events.forEach(eventString => {
+                            const eventTypeMatch = eventString.match(/^event: (.*)$/m);
+                            const dataMatch = eventString.match(/^data: (.*)$/m);
+                            if (!eventTypeMatch || !dataMatch) return;
+
+                            const eventType = eventTypeMatch[1];
+                            const data = JSON.parse(dataMatch[1]);
+
+                            if (eventType === 'update') {
+                                const { key, value } = data;
+                                const textarea = document.getElementById(key);
+                                const iconEl = document.getElementById(`icon-${key}`);
+
+                                if (textarea) {
+                                    textarea.value = value;
+                                    textarea.readOnly = false;
+                                    textarea.placeholder = '';
+                                    // 編集履歴管理の初期値を設定
+                                    defaultValues[key] = value;
+                                    updateElementStyle(textarea);
+                                }
+                                if (iconEl) {
+                                    iconEl.innerHTML = '<i class="bi bi-check-circle-fill text-success"></i>';
+                                }
+
+                            } else if (eventType === 'finished') {
+                                generationHeaderStatus.classList.remove('alert-info');
+                                generationHeaderStatus.classList.add('alert-success');
+                                generationHeaderStatus.innerHTML = '<div class="d-flex align-items-center"><i class="bi bi-check-circle-fill me-2"></i><strong>AIによる生成がすべて完了しました。</strong></div>';
+                                generationFinishedText.style.display = 'block';
+
+                                submitButton.disabled = false;
+                                submitButton.textContent = 'この内容で確定して保存';
+
+                                // 全ての生成が終わったら、再度Undo/Redo用の初期値を設定
+                                initializeDefaultValues();
+
+                            } else if (eventType === 'error') {
+                                generationHeaderStatus.classList.remove('alert-info');
+                                generationHeaderStatus.classList.add('alert-danger');
+                                generationHeaderStatus.innerHTML = `<div class="d-flex align-items-center"><i class="bi bi-exclamation-triangle-fill me-2"></i><strong>エラー:</strong> ${data.error}</div>`;
+                                submitButton.disabled = true;
+                                submitButton.textContent = 'エラーが発生しました';
+                            }
+                        });
+                        push();
+                    });
+                }
+                push();
+            }).catch(error => {
+                console.error('Fetch error:', error);
+                generationHeaderStatus.innerHTML = `サーバーとの通信に失敗しました: ${error.message}`;
+                generationHeaderStatus.classList.add('alert-danger');
+            });
+            {% endif %}
         });
     </script>
 </body>


### PR DESCRIPTION

<img width="626" height="745" alt="スクリーンショット 2025-09-14 215757" src="https://github.com/user-attachments/assets/4c0355a4-ff5d-43e7-86d7-efc276cecd14" />

非同期処理
・各テキストエリアに生成結果が一つずつ反映されるように
・各項目の横にアイコンを設置し生成が完了するまでは読み込みマークを表示
　生成が完了したらチェックマークに切り替わるように
・AIが生成するまでのテキストエリアは編集不可に設定し、生成されると編集可能に
・すべての項目で生成が完了するとページ上部の表示が完了になり、下のボタンで出力が可能になる

リハビリプラン生成の分割
・生成ステップを3つのグループに分割し、前ステップでの生成内容をデータに、より一貫性のあるリハビリプランの提示が可能に